### PR TITLE
Add implements to interface services

### DIFF
--- a/GuideAPI/Application/Interfaces/IPlacesService.cs
+++ b/GuideAPI/Application/Interfaces/IPlacesService.cs
@@ -16,9 +16,6 @@ namespace GuideAPI.Application.Interfaces
         // Get detailed information about a place by Id
         Task<NearbyPlaceDTO?> GetPlaceDetailsAsync(string placeId);
 
-        // Generate a Google Maps link for a place
-        string GenerateGoogleMapsLink(string placeId);
-
         // Get photo URLs for a specific place
         Task<IReadOnlyList<string>> GetPlacePhotoUrlsAsync(string placeId);
     }

--- a/GuideAPI/Application/Services/PlacesService.cs
+++ b/GuideAPI/Application/Services/PlacesService.cs
@@ -1,4 +1,5 @@
-﻿using GuideAPI.Application.Interfaces;
+﻿using System.Text.Json;
+using GuideAPI.Application.Interfaces;
 using GuideAPI.Domain.DTOs;
 using GuideAPI.Domain.Models;
 
@@ -6,29 +7,157 @@ namespace GuideAPI.Application.Services
 {
     public class PlacesService : IPlacesService
     {
-        public string GenerateGoogleMapsLink(string placeId)
+        private readonly HttpClient _httpClient;
+        private readonly string _apiKey;
+        private const string BaseUrl = "https://places.googleapis.com/v1/places";
+
+        public PlacesService(HttpClient httpClient, string apiKey)
         {
-            throw new NotImplementedException();
+            _httpClient = httpClient;
+            _apiKey = apiKey;
         }
 
-        public Task<NearbyPlaceDTO?> GetPlaceDetailsAsync(string placeId)
+        // Search for nearby places by request parameters
+        public async Task<NearbyPlacesResponseDTO> SearchNearbyAsync(SearchNearbyRequest request)
         {
-            throw new NotImplementedException();
+            var url = $"{BaseUrl}:searchNearby";
+            var fieldMask = GetNearbySearchFieldMask();
+
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
+            httpRequest.Headers.Add("X-Goog-Api-Key", _apiKey);
+            httpRequest.Headers.Add("X-Goog-FieldMask", fieldMask);
+            httpRequest.Content = JsonContent.Create(request);
+
+            var response = await _httpClient.SendAsync(httpRequest);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            var searchNearbyResponse = JsonSerializer.Deserialize<SearchNearbyResponse>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            return MapToNearbyPlacesResponseDTO(searchNearbyResponse!);
         }
 
-        public Task<IReadOnlyList<string>> GetPlacePhotoUrlsAsync(string placeId)
+        // Get detailed information about a place by Id
+        public async Task<NearbyPlaceDTO?> GetPlaceDetailsAsync(string placeId)
         {
-            throw new NotImplementedException();
+            var url = $"{BaseUrl}/{placeId}";
+            var fieldMask = GetNearbySearchFieldMask();
+
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Get, url);
+            httpRequest.Headers.Add("X-Goog-Api-Key", _apiKey);
+            httpRequest.Headers.Add("X-Goog-FieldMask", fieldMask);
+
+            var response = await _httpClient.SendAsync(httpRequest);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var json = await response.Content.ReadAsStringAsync();
+            var place = JsonSerializer.Deserialize<Place>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            if (place == null)
+                return null;
+
+            return MapToNearbyPlaceDTO(place);
         }
 
+        // Convert domain SearchNearbyResponse to DTO
         public NearbyPlacesResponseDTO MapToNearbyPlacesResponseDTO(SearchNearbyResponse response)
         {
-            throw new NotImplementedException();
+            return new NearbyPlacesResponseDTO
+            {
+                Places = response.Places?.Select(MapToNearbyPlaceDTO).ToArray() ?? Array.Empty<NearbyPlaceDTO>()
+            };
         }
 
-        public Task<NearbyPlacesResponseDTO> SearchNearbyAsync(SearchNearbyRequest request)
+        // Helper: Map Place to NearbyPlaceDTO
+        private static NearbyPlaceDTO MapToNearbyPlaceDTO(Place place)
         {
-            throw new NotImplementedException();
+            return new NearbyPlaceDTO
+            {
+                Id = place.Id,
+                Name = place.Name,
+                DisplayName = place.DisplayName?.Text,
+                PrimaryType = place.PrimaryType,
+                Latitude = place.Location?.Latitude ?? 0,
+                Longitude = place.Location?.Longitude ?? 0,
+                Rating = place.Rating,
+                UserRatingCount = place.UserRatingCount,
+                ShortFormattedAddress = place.ShortFormattedAddress,
+                PhoneNumber = place.NationalPhoneNumber,
+                WebsiteUri = place.WebsiteUri,
+                GoogleMapsUri = place.GoogleMapsUri,
+                PriceLevel = place.PriceLevel,
+                OpenNow = place.CurrentOpeningHours?.OpenNow,
+                WeekdayDescriptions = place.CurrentOpeningHours?.WeekdayDescriptions,
+                EditorialSummary = place.EditorialSummary?.Text,
+                GenerativeSummary = place.GenerativeSummary?.Overview?.Text
+            };
+        }
+        // Get photo URLs for a specific place
+        public async Task<IReadOnlyList<string>> GetPlacePhotoUrlsAsync(string placeId)
+        {
+            var url = $"{BaseUrl}/{placeId}";
+            var fieldMask = "photos"; // Only request photos field
+
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Get, url);
+            httpRequest.Headers.Add("X-Goog-Api-Key", _apiKey);
+            httpRequest.Headers.Add("X-Goog-FieldMask", fieldMask);
+
+            var response = await _httpClient.SendAsync(httpRequest);
+            if (!response.IsSuccessStatusCode)
+                return Array.Empty<string>();
+
+            var json = await response.Content.ReadAsStringAsync();
+
+            // Google Places API returns photos as an array of objects with at least a 'name' property (photo resource name)
+            // To get the actual photo, you need to request it via: https://places.googleapis.com/v1/{photo.name}
+            // For simplicity, return the photo resource URLs
+
+            using var doc = JsonDocument.Parse(json);
+            var photoUrls = new List<string>();
+
+            if (doc.RootElement.TryGetProperty("photos", out var photosElement) && photosElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var photo in photosElement.EnumerateArray())
+                {
+                    if (photo.TryGetProperty("name", out var nameElement))
+                    {
+                        // Construct the photo resource URL
+                        var photoResourceUrl = $"https://places.googleapis.com/v1/{nameElement.GetString()}";
+                        photoUrls.Add(photoResourceUrl);
+                    }
+                }
+            }
+
+            return photoUrls;
+        }
+
+        // Returns the field mask for Nearby Search requests
+        private static string GetNearbySearchFieldMask()
+        {
+            return string.Join(",",
+                "places.id",
+                "places.name",
+                "places.displayName",
+                "places.primaryType",
+                "places.location",
+                "places.rating",
+                "places.userRatingCount",
+                "places.shortFormattedAddress",
+                "places.nationalPhoneNumber",
+                "places.websiteUri",
+                "places.googleMapsUri",
+                "places.priceLevel",
+                "places.currentOpeningHours",
+                "places.editorialSummary",
+                "places.generativeSummary"
+            );
         }
     }
 }

--- a/GuideAPI/Program.cs
+++ b/GuideAPI/Program.cs
@@ -1,4 +1,7 @@
 
+using GuideAPI.Application.Interfaces;
+using GuideAPI.Application.Services;
+
 namespace GuideAPI
 {
     public class Program
@@ -13,6 +16,15 @@ namespace GuideAPI
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
+
+            //Register Services
+            builder.Services.AddHttpClient<IPlacesService, PlacesService>()
+                .AddTypedClient((httpClient, serviceProvider) =>
+    {
+        var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+        var apiKey = configuration["GooglePlaces:ApiKey"];
+        return new PlacesService(httpClient, apiKey);
+    });
 
             var app = builder.Build();
 

--- a/GuideAPI/appsettings.json
+++ b/GuideAPI/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "GooglePlaces": {
+    "ApiKey": "YOUR_API_KEY"
+  }
 }


### PR DESCRIPTION
This pull request introduces a new implementation for the `IPlacesService` interface, providing full integration with the Google Places API. It adds methods for searching nearby places, retrieving place details, and fetching photo URLs, and wires up dependency injection for these services using configuration-based API keys. The previously unimplemented or placeholder methods are now fully realized, and the codebase is updated to support these changes.

**Google Places API Integration:**

* Implemented `PlacesService` to interact with the Google Places API, including methods for searching nearby places, retrieving detailed place information, and fetching photo URLs. The service uses an injected `HttpClient` and API key from configuration. [[1]](diffhunk://#diff-f0692718e39236740749759d8701c80dfef5f50ea76fad518b44da32a2960948L1-R160) [[2]](diffhunk://#diff-f0692718e39236740749759d8701c80dfef5f50ea76fad518b44da32a2960948L1-R160)
* Removed the unused `GenerateGoogleMapsLink` method from the `IPlacesService` interface, reflecting its removal from the service implementation.

**Dependency Injection and Configuration:**

* Registered `PlacesService` as an `IPlacesService` implementation using `AddHttpClient` in the DI container, with the API key loaded from the `GooglePlaces:ApiKey` configuration section. [[1]](diffhunk://#diff-80cb41dd7d9f292b30f9edd21edcf308c5dfcc58e24ce1f165e46a7877523e62R20-R28) [[2]](diffhunk://#diff-80cb41dd7d9f292b30f9edd21edcf308c5dfcc58e24ce1f165e46a7877523e62R2-R4)
* Added a new `GooglePlaces` section to `appsettings.json` for storing the API key, enabling secure and flexible configuration.